### PR TITLE
Update Flatpak manifest

### DIFF
--- a/io.itch.domestique_baston.kindergarten_massaker.yml
+++ b/io.itch.domestique_baston.kindergarten_massaker.yml
@@ -25,11 +25,11 @@ modules:
       url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/releases/download/v1.0.1/km.pck'
       sha256: 'fe473c17836fba328fc407b0443408bc53c8402033a67406fc21a5f746a81d49'
     - type: file
-      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/io.github.domestiquebaston.kindergarten_massaker.desktop'
-      sha256: '25e97e3d322a8d4fe5adb65e41ee61235a2e742ad35adad31086fc2c9da3096a'
+      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/io.itch.domestique_baston.kindergarten_massaker.desktop'
+      sha256: 'e415a666800f3100a1d7ac6873c4005232d1a986f357188909b766180f4c071b'
     - type: file
-      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/io.github.domestiquebaston.kindergarten_massaker.metainfo.xml'
-      sha256: '9fd0e89ccb391a419c46cd5fd5519d96030ec985d357610a77f79d25909db47a'
+      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/io.itch.domestique_baston.kindergarten_massaker.metainfo.xml'
+      sha256: '7e4af8bb3128ea1d961f1108072c2d46982a54812763dca0196bcfbe2bf45dba'
     - type: file
       url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/GODOT/KM_LOGO.png'
       sha256: '33ff96152b641b9fd58072564079a1c00d13cf9f70aea9df0ab362508114ca97'

--- a/io.itch.domestique_baston.kindergarten_massaker.yml
+++ b/io.itch.domestique_baston.kindergarten_massaker.yml
@@ -1,8 +1,8 @@
 id: io.itch.domestique_baston.kindergarten_massaker
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 base: org.godotengine.godot.BaseApp
-base-version: '3.5-23.08'
+base-version: '3.5-24.08'
 sdk: org.freedesktop.Sdk
 command: godot-runner
 finish-args:
@@ -14,13 +14,25 @@ modules:
   - name: kindergarten_massaker
     buildsystem: simple
     build-commands:
-      - install -D -m 0644 KM.pck /app/bin/godot-runner.pck
+      - install -D -m 0644 km.pck /app/bin/godot-runner.pck
       - install -d /app/share/doc/$FLATPAK_ID
       - install -D -m 0644 *.pdf /app/share/doc/$FLATPAK_ID
-      - install -D -m 0644 io.itch.domestique_baston.kindergarten_massaker.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml
-      - install -D -m 0644 io.itch.domestique_baston.kindergarten_massaker.desktop /app/share/applications/$FLATPAK_ID.desktop
+      - install -D -m 0644 $FLATPAK_ID.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml
+      - install -D -m 0644 $FLATPAK_ID.desktop /app/share/applications/$FLATPAK_ID.desktop
       - install -D -m 0644 KM_LOGO.png /app/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
     sources:
-    - type: archive
-      url: 'http://www.ferdiferdi.com/km/KM_LIN.zip'
-      sha256: '0f1893be1a8854fa39b6c4c360df8c365f617b7bf693e84ec5fb8f8712b3d1db'
+    - type: file
+      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/releases/download/v1.0.1/km.pck'
+      sha256: 'fe473c17836fba328fc407b0443408bc53c8402033a67406fc21a5f746a81d49'
+    - type: file
+      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/io.github.domestiquebaston.kindergarten_massaker.desktop'
+      sha256: '25e97e3d322a8d4fe5adb65e41ee61235a2e742ad35adad31086fc2c9da3096a'
+    - type: file
+      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/io.github.domestiquebaston.kindergarten_massaker.metainfo.xml'
+      sha256: '9fd0e89ccb391a419c46cd5fd5519d96030ec985d357610a77f79d25909db47a'
+    - type: file
+      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/GODOT/KM_LOGO.png'
+      sha256: '33ff96152b641b9fd58072564079a1c00d13cf9f70aea9df0ab362508114ca97'
+    - type: file
+      url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/Docs/How_to_play.pdf'
+      sha256: 'e55d080d4cc7bb3d4f46d06cf046bff02148a61caf98c0b86075f8ec2f6cd2fb'

--- a/io.itch.domestique_baston.kindergarten_massaker.yml
+++ b/io.itch.domestique_baston.kindergarten_massaker.yml
@@ -29,7 +29,7 @@ modules:
       sha256: 'e415a666800f3100a1d7ac6873c4005232d1a986f357188909b766180f4c071b'
     - type: file
       url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/io.itch.domestique_baston.kindergarten_massaker.metainfo.xml'
-      sha256: '7e4af8bb3128ea1d961f1108072c2d46982a54812763dca0196bcfbe2bf45dba'
+      sha256: 'ed19579b8ca6e0da3493185f46f3e5d77a321c824bffd943aca863a223425166'
     - type: file
       url: 'https://github.com/DomestiqueBaston/KINDERGARTEN_MASSAKER/raw/refs/tags/v1.0.1/GODOT/KM_LOGO.png'
       sha256: '33ff96152b641b9fd58072564079a1c00d13cf9f70aea9df0ab362508114ca97'


### PR DESCRIPTION
Bump to freedesktop 24.08.
Fetch files from GitHub, not www.ferdiferdi.com.